### PR TITLE
Fix link to code of conduct.

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines
 
-Please note that this project is released with a [Contributor Code of Conduct](code-of-conduct.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](code_of_conduct.md). By participating in this project you agree to abide by its terms.
 
 ---
 


### PR DESCRIPTION
Link to code of conduct used - instead of _..